### PR TITLE
Merge Valid Epochs

### DIFF
--- a/Notebooks/Bruxism_detection.ipynb
+++ b/Notebooks/Bruxism_detection.ipynb
@@ -303,7 +303,20 @@
     "# Merge is_good and amplitude\n",
     "#TODO: THERE IS A MISSMATCH BETWEEN LABEL SIZE\n",
     "valid_labels = np.any(np.c_[np.invert(impedance_labels),  amplitude_labels], axis=-1) # Logical OR\n",
-    "print(valid_labels[:3])"
+    "print(valid_labels[:3])\n",
+    "\n",
+    "dict_annotations_artefacts = {1: \"artefact\"}\n",
+    "annotations_artefacts = []\n",
+    "for k, label in enumerate(np.invert(valid_labels)):\n",
+    "    if label > 0:\n",
+    "        annotations.append(dict(\n",
+    "            onset=k*interval/sfreq,\n",
+    "            duration=duration/sfreq,\n",
+    "            description=dict_annotations[label],\n",
+    "            orig_time=offset\n",
+    "        )\n",
+    "            \n",
+    "        )"
    ]
   },
   {
@@ -334,8 +347,9 @@
    "source": [
     "# compute the sum of power over electrodes and samples in each window\n",
     "pipeline = AmplitudeThresholding(abs_threshold=0., rel_threshold=2)\n",
-    "X        = rms(epochs)\n",
+    "X        = rms(epochs[valid_labels]) # take only valid labels\n",
     "labels   = pipeline.fit_predict(X)\n",
+    "labels   = fuse_with_classif_result(np.invert(valid_labels), labels) # add the missing labels removed with artefacts\n",
     "print(f\"bursts count: {np.sum(labels)}/{len(labels)} ({np.sum(labels) / len(labels) * 100:.2f}%)\")\n",
     "print(f\"bursts time: {np.sum(labels) * window_length} seconds\")\n",
     "\n",
@@ -405,6 +419,8 @@
     "ax1 = plt.subplot(211)\n",
     "plotTimeSeries(raw_ds.get_data().T, sfreq=raw_ds.info[\"sfreq\"], ax=ax1, scalings=scalings, offset=offset)\n",
     "plotAnnotations(annotations, color=\"red\")\n",
+    "plotAnnotations(annotations_artefacts, color=\"green\")\n",
+    "\n",
     "ax1.set_xlim(5145,5165)\n",
     "ax2 = plt.subplot(212)\n",
     "plotTimeSeries(raw_ds.get_data().T, sfreq=raw_ds.info[\"sfreq\"], ax=ax2, scalings=scalings, offset=offset)\n",

--- a/Notebooks/Bruxism_detection.ipynb
+++ b/Notebooks/Bruxism_detection.ipynb
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 17,
    "metadata": {
     "jupyter": {
      "outputs_hidden": false
@@ -89,7 +89,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-2-46caa3af125e>:4: RuntimeWarning: 7 channel names are too long, have been truncated to 15 characters:\n",
+      "<ipython-input-17-88ec8227bc83>:4: RuntimeWarning: 7 channel names are too long, have been truncated to 15 characters:\n",
       "['Inductance Abdom', 'Inductance Thora', 'Intensit? lumine', 'Jambe droite Imp', 'Jambe gauche Imp', 'Tension (aliment', 'Tension (Bluetoo']\n",
       "  raw  = mne.io.read_raw_edf(filename, preload=False)  # prepare loading\n"
      ]
@@ -98,8 +98,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epochs done, shape (104900, 2, 50)\n",
-      "Data loaded\n",
       "Data filtered\n",
       "keeping 7.28 hours of recording out of 8.83 hours\n"
      ]
@@ -117,8 +115,6 @@
     "raw.crop(**croptimes)\n",
     "\n",
     "raw  = CreateRaw(raw[picks_chan][0], picks_chan, ch_types=['emg'])        # pick channels and load\n",
-    "raw  = raw.load_data()  # load data into memory \n",
-    "print(\"Data loaded\")\n",
     "\n",
     "raw  = raw.filter(20., 99., n_jobs=4, \n",
     "                  fir_design='firwin', filter_length='auto', phase='zero-double',\n",
@@ -143,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 18,
    "metadata": {
     "pycharm": {
      "is_executing": false,

--- a/Notebooks/Bruxism_detection.ipynb
+++ b/Notebooks/Bruxism_detection.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "metadata": {
     "pycharm": {
      "is_executing": false
@@ -50,7 +50,6 @@
     "from tinnsleep.check_impedance import create_annotation_mne, Impedance_thresholding_sliding, check_RMS, fuse_with_classif_result\n",
     "from tinnsleep.signal import rms\n",
     "from tinnsleep.visualization import plotTimeSeries, plotAnnotations, zoom_effect\n",
-    "\n",
     "from IPython.core.display import display\n",
     "from ipywidgets import widgets\n",
     "print(\"Config loaded\")\n"
@@ -67,7 +66,6 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -81,7 +79,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extracting EDF parameters from /Users/louis/Data/SIOPI/bruxisme/1BA07_nuit_hab.edf...\n",
+      "Extracting EDF parameters from C:\\Users\\zeta\\documents\\EEG_polysomno\\PSG2\\1BA07_nuit_hab.edf...\n",
       "EDF file detected\n",
       "Setting channel info structure...\n",
       "Creating raw.info structure...\n"
@@ -91,7 +89,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-2-3ad3c8147a94>:4: RuntimeWarning: 7 channel names are too long, have been truncated to 15 characters:\n",
+      "<ipython-input-2-46caa3af125e>:4: RuntimeWarning: 7 channel names are too long, have been truncated to 15 characters:\n",
       "['Inductance Abdom', 'Inductance Thora', 'Intensit? lumine', 'Jambe droite Imp', 'Jambe gauche Imp', 'Tension (aliment', 'Tension (Bluetoo']\n",
       "  raw  = mne.io.read_raw_edf(filename, preload=False)  # prepare loading\n"
      ]
@@ -100,9 +98,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Epochs done, shape (104900, 2, 50)\n",
       "Data loaded\n",
       "Data filtered\n",
-      "keeping 8.03 hours of recording out of 11.03 hours\n"
+      "keeping 7.28 hours of recording out of 8.83 hours\n"
      ]
     }
    ],
@@ -111,6 +110,12 @@
     "picks_chan = ['1', '2']           # subset of EMG electrodes\n",
     "\n",
     "raw  = mne.io.read_raw_edf(filename, preload=False)  # prepare loading\n",
+    "tmin = raw.times[0]                     \n",
+    "tmax = raw.times[-1]\n",
+    "\n",
+    "croptimes=dict(tmin=raw.times[0]+3600*2, tmax=raw.times[-1]-3600)\n",
+    "raw.crop(**croptimes)\n",
+    "\n",
     "raw  = CreateRaw(raw[picks_chan][0], picks_chan, ch_types=['emg'])        # pick channels and load\n",
     "raw  = raw.load_data()  # load data into memory \n",
     "print(\"Data loaded\")\n",
@@ -121,12 +126,10 @@
     "ch_names = raw.info[\"ch_names\"]\n",
     "print(\"Data filtered\")\n",
     "\n",
-    "tmin = raw.times[0]                     \n",
-    "tmax = raw.times[-1]\n",
+    "\n",
     "\n",
     "# remove the two first hours and last hour\n",
-    "croptimes=dict(tmin=raw.times[0]+3600*2, tmax=raw.times[-1]-3600)\n",
-    "raw.crop(**croptimes)\n",
+    "\n",
     "offset = raw.times[0]\n",
     "print(f\"keeping {(raw.times[-1]-raw.times[0])/3600:0.2f} hours of recording out of {(tmax-tmin)/3600:0.2f} hours\")"
    ]
@@ -152,7 +155,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epochs done, shape (115700, 2, 50)\n"
+      "Epochs done, shape (104900, 2, 50)\n"
      ]
     }
    ],
@@ -162,7 +165,7 @@
     "duration = int(window_length * sfreq)   # in samples\n",
     "interval = duration                     # no overlapping\n",
     "epochs = RawToEpochs_sliding(raw, duration=duration, interval=interval)\n",
-    "print(f\"Epochs done, shape {epochs.shape}\")"
+    "print(f\"Epochs done, shape {epochs.shape}\")\n"
    ]
   },
   {
@@ -174,14 +177,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extracting EDF parameters from /Users/louis/Data/SIOPI/bruxisme/1BA07_nuit_hab.edf...\n",
+      "Extracting EDF parameters from C:\\Users\\zeta\\documents\\EEG_polysomno\\PSG2\\1BA07_nuit_hab.edf...\n",
       "EDF file detected\n",
       "Setting channel info structure...\n",
       "Creating raw.info structure...\n",
@@ -192,7 +195,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-60-f0e3994e2db5>:4: RuntimeWarning: 7 channel names are too long, have been truncated to 15 characters:\n",
+      "<ipython-input-4-97476cdf5950>:4: RuntimeWarning: 7 channel names are too long, have been truncated to 15 characters:\n",
       "['Inductance Abdom', 'Inductance Thora', 'Intensit? lumine', 'Jambe droite Imp', 'Jambe gauche Imp', 'Tension (aliment', 'Tension (Bluetoo']\n",
       "  raw_imp  = mne.io.read_raw_edf(filename, preload=False)  # prepare loading\n"
      ]
@@ -204,7 +207,7 @@
       "[[False False]\n",
       " [False False]\n",
       " [False False]]\n",
-      "rejected impedances for 26 epochs out of 158900 (0.02%)\n"
+      "rejected impedances for 26 epochs out of 104900 (0.02%)\n"
      ]
     }
    ],
@@ -217,6 +220,9 @@
     "picks_chan = [ch_names[1],ch_names[5]]\n",
     "print(picks_chan)\n",
     "\n",
+    "croptimes=dict(tmin=raw_imp.times[0]+3600*2, tmax=raw_imp.times[-1]-3600)\n",
+    "raw_imp.crop(**croptimes)\n",
+    "\n",
     "#Get the table of bad electrodes booleans from the impedance thresholding algo\n",
     "check_imp  = Impedance_thresholding_sliding(raw_imp[picks_chan][0], duration, interval,THR_imp) \n",
     "print(check_imp[:3])\n",
@@ -228,17 +234,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mean [-9.05867275e-13 -1.18524668e-12]\n",
-      "median [2.65982311e-08 1.10616584e-08]\n",
-      "quantile 0.05 [-6.97165086e-06 -7.10919239e-06]\n",
-      "quantile 0.95 [6.93789249e-06 7.09388268e-06]\n"
+      "mean [-3.18235151e-13 -1.89347516e-12]\n",
+      "median [2.82419815e-08 1.01926332e-08]\n",
+      "quantile 0.05 [-7.01076668e-06 -7.10918958e-06]\n",
+      "quantile 0.95 [6.95685044e-06 7.09699822e-06]\n"
      ]
     }
    ],
@@ -252,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -261,7 +267,7 @@
      "text": [
       "[True, True, True, True, True, True, True, True, True, True]\n",
       "[None, None, None, None, None, None, None, None, None, None]\n",
-      "good amplitudes for 112938 epochs out of 115700 (97.61%)\n"
+      "good amplitudes for 102344 epochs out of 104900 (97.56%)\n"
      ]
     }
    ],
@@ -275,27 +281,21 @@
     "             full_report=True\n",
     "            )\n",
     "amplitude_labels, bad_lists = is_good_epochs(epochs, **params)\n",
-    "print(labels[:10])\n",
+    "print(amplitude_labels[:10])\n",
     "print(bad_lists[:10])\n",
     "print(f\"good amplitudes for {np.sum(amplitude_labels)} epochs out of {len(amplitude_labels)} ({np.sum(amplitude_labels)/len(amplitude_labels)*100:.2f}%)\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
-     "ename": "ValueError",
-     "evalue": "all the input array dimensions for the concatenation axis must match exactly, but along dimension 0, the array at index 0 has size 158900 and the array at index 1 has size 115700",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-63-d367d2b6c988>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Merge is_good and amplitude\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mvalid_labels\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mc_\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minvert\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mimpedance_labels\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m  \u001b[0mamplitude_labels\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalid_labels\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/tinnsleep-env/lib/python3.8/site-packages/numpy/lib/index_tricks.py\u001b[0m in \u001b[0;36m__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    404\u001b[0m                 \u001b[0mobjs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mobjs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mastype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfinal_dtype\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    405\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 406\u001b[0;31m         \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mconcatenate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtuple\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobjs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0maxis\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    407\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    408\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mmatrix\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m<__array_function__ internals>\u001b[0m in \u001b[0;36mconcatenate\u001b[0;34m(*args, **kwargs)\u001b[0m\n",
-      "\u001b[0;31mValueError\u001b[0m: all the input array dimensions for the concatenation axis must match exactly, but along dimension 0, the array at index 0 has size 158900 and the array at index 1 has size 115700"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ True  True  True]\n"
      ]
     }
    ],
@@ -309,10 +309,10 @@
     "annotations_artefacts = []\n",
     "for k, label in enumerate(np.invert(valid_labels)):\n",
     "    if label > 0:\n",
-    "        annotations.append(dict(\n",
+    "        annotations_artefacts.append(dict(\n",
     "            onset=k*interval/sfreq,\n",
     "            duration=duration/sfreq,\n",
-    "            description=dict_annotations[label],\n",
+    "            description=dict_annotations_artefacts[label],\n",
     "            orig_time=offset\n",
     "        )\n",
     "            \n",
@@ -328,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 13,
    "metadata": {
     "pycharm": {
      "is_executing": false
@@ -339,8 +339,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "bursts count: 7417/115700 (6.41%)\n",
-      "bursts time: 1854.25 seconds\n"
+      "bursts count: 6689/104900 (6.38%)\n",
+      "bursts time: 1672.25 seconds\n"
      ]
     }
    ],
@@ -380,9 +380,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 14,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -395,7 +394,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ef8e75274b8c4ac7b320a7f2c72c519b",
+       "model_id": "47bcbdc9791e4093b4dbcd0f9220331a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -429,9 +428,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -440,7 +438,18 @@
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5145, 5165)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# update manually the time axis\n",
     "ax1.set_xlim(5145,5165) # in seconds"
@@ -463,9 +472,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -478,12 +486,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4a70d9b7d8804402bdebaff0f7315a15",
+       "model_id": "2c84c76ebb394d7f86dcba2daabfa788",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "interactive(children=(FloatSlider(value=0.0, continuous_update=False, description='xmin', max=28924.995, step=…"
+       "interactive(children=(FloatSlider(value=0.0, continuous_update=False, description='xmin', max=26224.995, step=…"
       ]
      },
      "metadata": {},
@@ -501,13 +509,27 @@
     "from ipywidgets import FloatSlider\n",
     "interact(update_axis,xmin=i, xmax=ii);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tinnsleep-env",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "tinnsleep-env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -519,7 +541,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.3"
   },
   "pycharm": {
    "stem_cell": {

--- a/Notebooks/Bruxism_detection.ipynb
+++ b/Notebooks/Bruxism_detection.ipynb
@@ -300,8 +300,9 @@
     }
    ],
    "source": [
-    "# Merge is_good and amplitude THERE IS A MISSMATCH BETWEEN LABEL SIZE\n",
-    "valid_labels = np.c_[np.invert(impedance_labels),  amplitude_labels]\n",
+    "# Merge is_good and amplitude\n",
+    "#TODO: THERE IS A MISSMATCH BETWEEN LABEL SIZE\n",
+    "valid_labels = np.any(np.c_[np.invert(impedance_labels),  amplitude_labels], axis=-1) # Logical OR\n",
     "print(valid_labels[:3])"
    ]
   },

--- a/Notebooks/Bruxism_detection.ipynb
+++ b/Notebooks/Bruxism_detection.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {
     "pycharm": {
      "is_executing": false
@@ -47,6 +47,7 @@
     "from tinnsleep.config import Config\n",
     "from tinnsleep.data import CreateRaw, RawToEpochs_sliding, CleanAnnotations, AnnotateRaw_sliding\n",
     "from tinnsleep.classification import AmplitudeThresholding\n",
+    "from tinnsleep.check_impedance import create_annotation_mne, Impedance_thresholding_sliding, check_RMS, fuse_with_classif_result\n",
     "from tinnsleep.signal import rms\n",
     "from tinnsleep.visualization import plotTimeSeries, plotAnnotations, zoom_effect\n",
     "\n",
@@ -90,7 +91,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-2-bf07b369b378>:4: RuntimeWarning: 7 channel names are too long, have been truncated to 15 characters:\n",
+      "<ipython-input-2-3ad3c8147a94>:4: RuntimeWarning: 7 channel names are too long, have been truncated to 15 characters:\n",
       "['Inductance Abdom', 'Inductance Thora', 'Intensit? lumine', 'Jambe droite Imp', 'Jambe gauche Imp', 'Tension (aliment', 'Tension (Bluetoo']\n",
       "  raw  = mne.io.read_raw_edf(filename, preload=False)  # prepare loading\n"
      ]
@@ -141,10 +142,6 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "is_executing": false,
      "name": "#%%\n"
@@ -166,6 +163,146 @@
     "interval = duration                     # no overlapping\n",
     "epochs = RawToEpochs_sliding(raw, duration=duration, interval=interval)\n",
     "print(f\"Epochs done, shape {epochs.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get the impedance & artefacts annotations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting EDF parameters from /Users/louis/Data/SIOPI/bruxisme/1BA07_nuit_hab.edf...\n",
+      "EDF file detected\n",
+      "Setting channel info structure...\n",
+      "Creating raw.info structure...\n",
+      "['1 Imp?dance', '2 Imp?dance']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-60-f0e3994e2db5>:4: RuntimeWarning: 7 channel names are too long, have been truncated to 15 characters:\n",
+      "['Inductance Abdom', 'Inductance Thora', 'Intensit? lumine', 'Jambe droite Imp', 'Jambe gauche Imp', 'Tension (aliment', 'Tension (Bluetoo']\n",
+      "  raw_imp  = mne.io.read_raw_edf(filename, preload=False)  # prepare loading\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[False False]\n",
+      " [False False]\n",
+      " [False False]]\n",
+      "rejected impedances for 26 epochs out of 158900 (0.02%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Value of the impedance threshold\n",
+    "THR_imp = 5000\n",
+    "\n",
+    "raw_imp  = mne.io.read_raw_edf(filename, preload=False)  # prepare loading\n",
+    "ch_names = raw_imp.info[\"ch_names\"]\n",
+    "picks_chan = [ch_names[1],ch_names[5]]\n",
+    "print(picks_chan)\n",
+    "\n",
+    "#Get the table of bad electrodes booleans from the impedance thresholding algo\n",
+    "check_imp  = Impedance_thresholding_sliding(raw_imp[picks_chan][0], duration, interval,THR_imp) \n",
+    "print(check_imp[:3])\n",
+    "\n",
+    "# convert to labels per epoch\n",
+    "impedance_labels = np.any(check_imp, axis=-1)\n",
+    "print(f\"rejected impedances for {np.sum(impedance_labels)} epochs out of {len(impedance_labels)} ({np.sum(impedance_labels)/len(impedance_labels)*100:.2f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean [-9.05867275e-13 -1.18524668e-12]\n",
+      "median [2.65982311e-08 1.10616584e-08]\n",
+      "quantile 0.05 [-6.97165086e-06 -7.10919239e-06]\n",
+      "quantile 0.95 [6.93789249e-06 7.09388268e-06]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# baseline epochs amplitudes\n",
+    "print(f\"mean {np.mean(np.mean(epochs, axis=0), axis=-1)}\")\n",
+    "print(f\"median {np.median(np.median(epochs, axis=0), axis=-1)}\")\n",
+    "print(f\"quantile 0.05 {np.quantile(np.quantile(epochs, 0.05, axis=0),0.05, axis=-1)}\")\n",
+    "print(f\"quantile 0.95 {np.quantile(np.quantile(epochs, 0.95, axis=0),0.95, axis=-1)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[True, True, True, True, True, True, True, True, True, True]\n",
+      "[None, None, None, None, None, None, None, None, None, None]\n",
+      "good amplitudes for 112938 epochs out of 115700 (97.61%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Epoch rejection based on |min-max| thresholding \n",
+    "from tinnsleep.signal import is_good_epochs\n",
+    "params = dict(ch_names=raw.info[\"ch_names\"],\n",
+    "             rejection_thresholds=dict(emg=1e-04), # two order of magnitude higher q0.01\n",
+    "             flat_thresholds=dict(emg=1e-09),    # one order of magnitude lower median\n",
+    "             channel_type_idx=dict(emg=[0, 1]),\n",
+    "             full_report=True\n",
+    "            )\n",
+    "amplitude_labels, bad_lists = is_good_epochs(epochs, **params)\n",
+    "print(labels[:10])\n",
+    "print(bad_lists[:10])\n",
+    "print(f\"good amplitudes for {np.sum(amplitude_labels)} epochs out of {len(amplitude_labels)} ({np.sum(amplitude_labels)/len(amplitude_labels)*100:.2f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "all the input array dimensions for the concatenation axis must match exactly, but along dimension 0, the array at index 0 has size 158900 and the array at index 1 has size 115700",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-63-d367d2b6c988>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Merge is_good and amplitude\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mvalid_labels\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mc_\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minvert\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mimpedance_labels\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m  \u001b[0mamplitude_labels\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalid_labels\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/tinnsleep-env/lib/python3.8/site-packages/numpy/lib/index_tricks.py\u001b[0m in \u001b[0;36m__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    404\u001b[0m                 \u001b[0mobjs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mobjs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mastype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfinal_dtype\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    405\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 406\u001b[0;31m         \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mconcatenate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtuple\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobjs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0maxis\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    407\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    408\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mmatrix\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<__array_function__ internals>\u001b[0m in \u001b[0;36mconcatenate\u001b[0;34m(*args, **kwargs)\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: all the input array dimensions for the concatenation axis must match exactly, but along dimension 0, the array at index 0 has size 158900 and the array at index 1 has size 115700"
+     ]
+    }
+   ],
+   "source": [
+    "# Merge is_good and amplitude THERE IS A MISSMATCH BETWEEN LABEL SIZE\n",
+    "valid_labels = np.c_[np.invert(impedance_labels),  amplitude_labels]\n",
+    "print(valid_labels[:3])"
    ]
   },
   {

--- a/Notebooks/Bruxism_detection_draft.ipynb
+++ b/Notebooks/Bruxism_detection_draft.ipynb
@@ -788,9 +788,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "tinnsleep-env",
    "language": "python",
-   "name": "python3"
+   "name": "tinnsleep-env"
   },
   "language_info": {
    "codemirror_mode": {
@@ -802,7 +802,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.2"
   },
   "pycharm": {
    "stem_cell": {
@@ -815,5 +815,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tinnsleep/signal.py
+++ b/tinnsleep/signal.py
@@ -40,11 +40,11 @@ def is_good_epochs(epochs, **kwargs):
         >>> channel_type_idx = dict(eeg=[0, 1, 2, 4], eog=[5, 6])  # first 4 channels eeg and two last eog
     rejection_thresholds: dict | None
         the rejection threshold used for bad channel per channel_type, e.g.
-        >>> reject = dict(eog=150e-6, eeg=150e-6, emg=50e-3)
+        >>> rejection_thresholds = dict(eog=150e-6, eeg=150e-6, emg=50e-3)
         If None, bad channels won't be tested
     flat_thresholds: dict | None
         the flat threshold used for bad channel per channel_type, e.g.
-        >>> reject = dict(eog=5e-6, eeg=5e-6, emg=50e-6)
+        >>> flat_thresholds = dict(eog=5e-6, eeg=5e-6, emg=50e-6)
         If None, flat channels won't be tested
     full_report : bool (default: False)
         If full_report=True, it will give True/False as well as a list of all offending channels.


### PR DESCRIPTION
Several issues:
- [x] Impedance_thresholding_sliding returns 158900 epochs while there is only 115700 epochs BECAUSE `raw` was cropped (reason: remove awaken time). We should take care of that @RobinGuillard . Option1: remove EMG crop in cell "Load, filter, and prepare data"
. Option2: apply same crop in EMG and Impedance in cell "Get the impedance & artefacts annotations"
- [x] While I think of it, we SHOULDNT interpolate bad channels from good channels. Therefore only one label should be accepted per epoch (if one channel is bad: we remove the whole epoch). "Get the impedance & artefacts annotations" merge the output accordingly. Please check that. 
- [x] please re-run the whole file. Now it should work. If not, copypaste the error in this PR comment.

I let you commit as I won't be able to work on that soon.